### PR TITLE
Normalize LLM provider endpoint configuration

### DIFF
--- a/apps/server/src/providerUtils.ts
+++ b/apps/server/src/providerUtils.ts
@@ -1,0 +1,7 @@
+export function buildChatCompletionsUrl(apiBase: string): string {
+  const trimmed = apiBase.trim();
+  const withoutTrailingSlashes = trimmed.replace(/\/+$/, "");
+  const withoutVersion = withoutTrailingSlashes.replace(/\/v1$/, "");
+
+  return `${withoutVersion}/v1/chat/completions`;
+}

--- a/apps/server/test/providerUtils.test.ts
+++ b/apps/server/test/providerUtils.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildChatCompletionsUrl } from "../src/providerUtils";
+import { callProvider } from "../src/llmService";
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch() {
+  const fetchSpy = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "{\"trades\":[]}" // minimal valid JSON string
+          }
+        }
+      ]
+    }),
+    text: async () => ""
+  });
+  globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+  return fetchSpy;
+}
+
+describe("buildChatCompletionsUrl", () => {
+  it("appends the versioned path when base has no version", () => {
+    expect(buildChatCompletionsUrl("https://api.openai.com")).toBe(
+      "https://api.openai.com/v1/chat/completions"
+    );
+  });
+
+  it("normalizes a base that already includes /v1", () => {
+    expect(buildChatCompletionsUrl("https://api.openai.com/v1")).toBe(
+      "https://api.openai.com/v1/chat/completions"
+    );
+  });
+
+  it("handles a base that ends with /v1/", () => {
+    expect(buildChatCompletionsUrl("https://api.openai.com/v1/")).toBe(
+      "https://api.openai.com/v1/chat/completions"
+    );
+  });
+});
+
+describe("callProvider", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("uses the normalized chat completions endpoint", async () => {
+    const fetchSpy = mockFetch();
+
+    await callProvider(
+      {
+        id: 1,
+        name: "Test Provider",
+        type: "openai",
+        apiBase: "https://api.openai.com/v1",
+        apiKey: "test-key",
+        model: "gpt-4",
+        temperature: null,
+        maxTokens: null
+      },
+      {
+        model: "gpt-4",
+        temperature: 0,
+        max_tokens: null,
+        messages: []
+      }
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe("https://api.openai.com/v1/chat/completions");
+  });
+
+  it("appends /v1 when the provider base has no version suffix", async () => {
+    const fetchSpy = mockFetch();
+
+    await callProvider(
+      {
+        id: 1,
+        name: "Test Provider",
+        type: "openai",
+        apiBase: "https://api.openai.com",
+        apiKey: "test-key",
+        model: "gpt-4",
+        temperature: null,
+        maxTokens: null
+      },
+      {
+        model: "gpt-4",
+        temperature: 0,
+        max_tokens: null,
+        messages: []
+      }
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe("https://api.openai.com/v1/chat/completions");
+  });
+});


### PR DESCRIPTION
## Summary
- ensure chat completion requests normalize provider.apiBase values before calling the OpenAI endpoint
- add a reusable helper for chat completion URL construction with tests covering versioned and non-versioned apiBase inputs

## Testing
- pnpm --filter @paper-trading/server test

------
https://chatgpt.com/codex/tasks/task_e_68e1f0fc2b60832b927fd1d9058f159d