### PR TITLE
Use Yahoo-supported 6mo range literals

### DIFF
--- a/apps/web/src/components/dashboard.tsx
+++ b/apps/web/src/components/dashboard.tsx
@@ -21,7 +21,7 @@ export function Dashboard() {
   const { data: portfolio } = usePortfolio(currentPortfolioId ?? undefined);
   const { data: portfoliosData } = usePortfolios();
   const { data: tradesData } = useTrades(currentPortfolioId ?? undefined);
-  const equityQuery = useEquityCurve(portfolio?.positions ?? [], "6M");
+  const equityQuery = useEquityCurve(portfolio?.positions ?? [], "6mo");
   const quoteQuery = useQuote(selectedSymbol ?? undefined);
   const latestTrades = tradesData?.trades.slice(0, 5) ?? [];
 

--- a/apps/web/src/hooks/api.ts
+++ b/apps/web/src/hooks/api.ts
@@ -105,7 +105,7 @@ export function useQuote(symbol?: string) {
   });
 }
 
-export function useHistory(symbol?: string, range = "6M", interval = "1d") {
+export function useHistory(symbol?: string, range = "6mo", interval = "1d") {
   return useQuery({
     queryKey: ["history", symbol, range, interval],
     enabled: Boolean(symbol),
@@ -169,7 +169,7 @@ export interface EquityPoint {
   value: number;
 }
 
-export function useEquityCurve(positions: PortfolioPosition[], range = "6M") {
+export function useEquityCurve(positions: PortfolioPosition[], range = "6mo") {
   const symbols = useMemo(() => positions.map((position) => position.symbol).sort(), [positions]);
   return useQuery({
     queryKey: ["equity-curve", symbols, range],


### PR DESCRIPTION
## Summary
- switch default history and equity curve ranges to Yahoo Finance's `6mo` literal
- update the dashboard equity curve hook usage to request `6mo` while keeping the UI copy unchanged

## Testing
- pnpm --filter @paper-trading/web lint

------
https://chatgpt.com/codex/tasks/task_e_68e5af80aebc832bb87e5e731144d1b8