### PR TITLE
Add Vercel serverless entry and routes for Express API

### DIFF
--- a/apps/server/api/index.ts
+++ b/apps/server/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../src/server";
+
+export default app;

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "pnpm vercel-build"
+  "buildCommand": "pnpm vercel-build",
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/api/index"
+    }
+  ]
 }


### PR DESCRIPTION
### Motivation
- Enable deploying the existing Express app on Vercel by providing a serverless entry that re-exports the Express instance. 
- Ensure all incoming requests are routed to the serverless entry so API endpoints like `/api/portfolio` are reachable on Vercel. 
- Retain the existing build flow using `pnpm vercel-build` while adding routing configuration.

### Description
- Add `apps/server/api/index.ts` which imports `app` from `../src/server` and `export default app;` to expose the Express instance as a serverless handler. 
- Update `apps/server/vercel.json` to include a `routes` entry mapping `/(.*)` to `/api/index`. 
- No changes were required to `apps/server/src/server.ts` since it already exports the Express app via `export default app;`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ddf45320832aa136d0a8236efdec)